### PR TITLE
Add `assert_translation_missing` to work around bugs from i18n 1.14.0+

### DIFF
--- a/test/devise/passkeys/controllers/test_passkeys_controller_concern.rb
+++ b/test/devise/passkeys/controllers/test_passkeys_controller_concern.rb
@@ -2,9 +2,11 @@
 
 require "test_helper"
 require_relative "../../../test_helper/webauthn_test_helpers"
+require_relative "../../../test_helper/extra_assertions"
 
 class Devise::Passkeys::Controllers::TestPasskeysControllerConcern < ActionDispatch::IntegrationTest
   include WebAuthnTestHelpers
+  include ExtraAssertions
   include Devise::Test::IntegrationHelpers
 
   class TestPasskeyController < DeviseController
@@ -201,8 +203,7 @@ class Devise::Passkeys::Controllers::TestPasskeysControllerConcern < ActionDispa
              params: { passkey: { label: "Test", credential: raw_credential.to_json, reauthentication_token: token } }
 
         assert_response :bad_request
-        assert_equal ({ "message" => "translation missing: en.devise.test_passkey.user.webauthn_user_verified_verification_error" }),
-                     response.parsed_body
+        assert_translation_missing_message(translation_key: "en.devise.test_passkey.user.webauthn_user_verified_verification_error")
       end
     end
 
@@ -250,8 +251,7 @@ class Devise::Passkeys::Controllers::TestPasskeysControllerConcern < ActionDispa
              params: { passkey: { label: "Test", credential: raw_credential.to_json, reauthentication_token: token } }
 
         assert_response :bad_request
-        assert_equal ({ "message" => "translation missing: en.devise.test_passkey.user.webauthn_challenge_verification_error" }),
-                     response.parsed_body
+        assert_translation_missing_message(translation_key: "en.devise.test_passkey.user.webauthn_challenge_verification_error")
       end
     end
 
@@ -291,8 +291,7 @@ class Devise::Passkeys::Controllers::TestPasskeysControllerConcern < ActionDispa
              params: { passkey: { label: "Test", credential: "blahj", reauthentication_token: token } }
 
         assert_response :bad_request
-        assert_equal ({ "message" => "translation missing: en.devise.test_passkey.user.credential_missing_or_could_not_be_parsed" }),
-                     response.parsed_body
+        assert_translation_missing_message(translation_key: "en.devise.test_passkey.user.credential_missing_or_could_not_be_parsed")
       end
     end
 
@@ -331,8 +330,7 @@ class Devise::Passkeys::Controllers::TestPasskeysControllerConcern < ActionDispa
         post "/passkey/create", params: { passkey: { label: "Test", reauthentication_token: token } }
 
         assert_response :bad_request
-        assert_equal ({ "message" => "translation missing: en.devise.test_passkey.user.credential_missing_or_could_not_be_parsed" }),
-                     response.parsed_body
+        assert_translation_missing_message(translation_key: "en.devise.test_passkey.user.credential_missing_or_could_not_be_parsed")
       end
     end
 
@@ -376,8 +374,7 @@ class Devise::Passkeys::Controllers::TestPasskeysControllerConcern < ActionDispa
              params: { passkey: { label: "Test", credential: raw_credential.to_json, reauthentication_token: :blah } }
 
         assert_response :bad_request
-        assert_equal ({ "error" => "translation missing: en.devise.test_passkey.user.not_reauthenticated" }),
-                     response.parsed_body
+        assert_translation_missing_error(translation_key: "en.devise.test_passkey.user.not_reauthenticated")
       end
     end
   end
@@ -453,8 +450,7 @@ class Devise::Passkeys::Controllers::TestPasskeysControllerConcern < ActionDispa
 
     post "/passkey/#{passkey.id}/new_destroy_challenge"
     assert_response :bad_request
-    assert_equal ({ "error" => "translation missing: en.devise.test_passkey.user.must_be_at_least_one_passkey" }),
-                 response.parsed_body
+    assert_translation_missing_error(translation_key: "en.devise.test_passkey.user.must_be_at_least_one_passkey")
   end
 
   test "#new_destroy_challenge: other user passkey" do
@@ -547,8 +543,7 @@ class Devise::Passkeys::Controllers::TestPasskeysControllerConcern < ActionDispa
       delete "/passkey/#{passkey.id}"
     end
     assert_response :bad_request
-    assert_equal ({ "error" => "translation missing: en.devise.test_passkey.user.must_be_at_least_one_passkey" }),
-                 response.parsed_body
+    assert_translation_missing_error(translation_key: "en.devise.test_passkey.user.must_be_at_least_one_passkey")
   end
 
   test "#destroy: other user passkey" do
@@ -638,8 +633,7 @@ class Devise::Passkeys::Controllers::TestPasskeysControllerConcern < ActionDispa
       delete "/passkey/#{passkey.id}", params: { passkey: { reauthentication_token: "blah" } }
 
       assert_response :bad_request
-      assert_equal ({ "error" => "translation missing: en.devise.test_passkey.user.not_reauthenticated" }),
-                   response.parsed_body
+      assert_translation_missing_error(translation_key: "en.devise.test_passkey.user.not_reauthenticated")
     end
 
     assert_equal passkey, UserPasskey.find_by(id: passkey.id)
@@ -673,8 +667,7 @@ class Devise::Passkeys::Controllers::TestPasskeysControllerConcern < ActionDispa
       delete "/passkey/#{passkey.id}", params: { passkey: { value: "blah" } }
 
       assert_response :bad_request
-      assert_equal ({ "error" => "translation missing: en.devise.test_passkey.user.not_reauthenticated" }),
-                   response.parsed_body
+      assert_translation_missing_error(translation_key: "en.devise.test_passkey.user.not_reauthenticated")
     end
 
     assert_equal passkey, UserPasskey.find_by(id: passkey.id)
@@ -708,8 +701,7 @@ class Devise::Passkeys::Controllers::TestPasskeysControllerConcern < ActionDispa
       delete "/passkey/#{passkey.id}", params: { passkey: { reauthentication_token: "asdasdsadasd" } }
 
       assert_response :bad_request
-      assert_equal ({ "error" => "translation missing: en.devise.test_passkey.user.not_reauthenticated" }),
-                   response.parsed_body
+      assert_translation_missing_error(translation_key: "en.devise.test_passkey.user.not_reauthenticated")
     end
 
     assert_equal passkey, UserPasskey.find_by(id: passkey.id)

--- a/test/devise/passkeys/controllers/test_reauthentication_controller_concern.rb
+++ b/test/devise/passkeys/controllers/test_reauthentication_controller_concern.rb
@@ -2,9 +2,11 @@
 
 require "test_helper"
 require_relative "../../../test_helper/webauthn_test_helpers"
+require_relative "../../../test_helper/extra_assertions"
 
 class Devise::Passkeys::Controllers::TestReauthenticationControllerConcern < ActionDispatch::IntegrationTest
   include WebAuthnTestHelpers
+  include ExtraAssertions
   include Devise::Test::IntegrationHelpers
 
   class TestReauthenticationController < ActionController::Base
@@ -125,8 +127,7 @@ class Devise::Passkeys::Controllers::TestReauthenticationControllerConcern < Act
 
     response_json = JSON.parse(response.body)
 
-    assert_equal ({ "error" => "translation missing: en.devise.failure.user.webauthn_user_verified_verification_error" }),
-                 response.parsed_body
+    assert_translation_missing_error(translation_key: "en.devise.failure.user.webauthn_user_verified_verification_error")
     assert_nil session["user_current_reauthentication_challenge"]
     assert_response :unauthorized
   end
@@ -156,8 +157,7 @@ class Devise::Passkeys::Controllers::TestReauthenticationControllerConcern < Act
 
     response_json = JSON.parse(response.body)
 
-    assert_equal ({ "error" => "translation missing: en.devise.failure.user.webauthn_challenge_verification_error" }),
-                 response.parsed_body
+    assert_translation_missing_error(translation_key: "en.devise.failure.user.webauthn_challenge_verification_error")
     assert_nil session["user_current_reauthentication_challenge"]
     assert_response :unauthorized
   end
@@ -189,8 +189,7 @@ class Devise::Passkeys::Controllers::TestReauthenticationControllerConcern < Act
 
     response_json = JSON.parse(response.body)
 
-    assert_equal ({ "error" => "translation missing: en.devise.failure.user.stored_credential_not_found" }),
-                 response.parsed_body
+    assert_translation_missing_error(translation_key: "en.devise.failure.user.stored_credential_not_found")
     assert_nil session["user_current_reauthentication_challenge"]
     assert_response :unauthorized
   end

--- a/test/devise/passkeys/controllers/test_registrations_controller_concern.rb
+++ b/test/devise/passkeys/controllers/test_registrations_controller_concern.rb
@@ -2,9 +2,11 @@
 
 require "test_helper"
 require_relative "../../../test_helper/webauthn_test_helpers"
+require_relative "../../../test_helper/extra_assertions"
 
 class Devise::Passkeys::Controllers::TestRegistrationsControllerConcern < ActionDispatch::IntegrationTest
   include WebAuthnTestHelpers
+  include ExtraAssertions
   include Devise::Test::IntegrationHelpers
 
   class TestRegistrationController < Devise::RegistrationsController
@@ -154,8 +156,7 @@ class Devise::Passkeys::Controllers::TestRegistrationsControllerConcern < Action
                                passkey_credential: raw_credential.to_json } }
 
         assert_response :bad_request
-        assert_equal ({ "message" => "translation missing: en.devise.registrations.user.webauthn_user_verified_verification_error" }),
-                     response.parsed_body
+        assert_translation_missing_message(translation_key: "en.devise.registrations.user.webauthn_user_verified_verification_error")
       end
     end
   end
@@ -180,8 +181,7 @@ class Devise::Passkeys::Controllers::TestRegistrationsControllerConcern < Action
                                passkey_credential: raw_credential.to_json } }
 
         assert_response :bad_request
-        assert_equal ({ "message" => "translation missing: en.devise.registrations.user.webauthn_challenge_verification_error" }),
-                     response.parsed_body
+        assert_translation_missing_message(translation_key: "en.devise.registrations.user.webauthn_challenge_verification_error")
       end
     end
   end
@@ -245,8 +245,7 @@ class Devise::Passkeys::Controllers::TestRegistrationsControllerConcern < Action
         post "/registration", params: { user: { email: "test@test.com", passkey_credential: raw_credential.to_json } }
 
         assert_response :bad_request
-        assert_equal ({ "message" => "translation missing: en.devise.registrations.user.passkey_label_missing" }),
-                     response.parsed_body
+        assert_translation_missing_message(translation_key: "en.devise.registrations.user.passkey_label_missing")
       end
     end
   end
@@ -269,8 +268,7 @@ class Devise::Passkeys::Controllers::TestRegistrationsControllerConcern < Action
         post "/registration", params: { user: { passkey_label: "Test", passkey_credential: raw_credential.to_json } }
 
         assert_response :bad_request
-        assert_equal ({ "message" => "translation missing: en.devise.registrations.user.email_missing" }),
-                     response.parsed_body
+        assert_translation_missing_message(translation_key: "en.devise.registrations.user.email_missing")
       end
     end
   end
@@ -324,8 +322,7 @@ class Devise::Passkeys::Controllers::TestRegistrationsControllerConcern < Action
     end
 
     assert_response :bad_request
-    assert_equal ({ "error" => "translation missing: en.devise.registrations.user.not_reauthenticated" }),
-                 response.parsed_body
+    assert_translation_missing_error(translation_key: "en.devise.registrations.user.not_reauthenticated")
 
     assert_equal "test@test.com", user.reload.email
 
@@ -347,8 +344,7 @@ class Devise::Passkeys::Controllers::TestRegistrationsControllerConcern < Action
     end
 
     assert_response :bad_request
-    assert_equal ({ "error" => "translation missing: en.devise.registrations.user.not_reauthenticated" }),
-                 response.parsed_body
+    assert_translation_missing_error(translation_key: "en.devise.registrations.user.not_reauthenticated")
 
     assert_equal "test@test.com", user.reload.email
 
@@ -370,8 +366,7 @@ class Devise::Passkeys::Controllers::TestRegistrationsControllerConcern < Action
     end
 
     assert_response :bad_request
-    assert_equal ({ "error" => "translation missing: en.devise.registrations.user.not_reauthenticated" }),
-                 response.parsed_body
+    assert_translation_missing_error(translation_key: "en.devise.registrations.user.not_reauthenticated")
 
     assert_equal "test@test.com", user.reload.email
 
@@ -413,8 +408,7 @@ class Devise::Passkeys::Controllers::TestRegistrationsControllerConcern < Action
     end
 
     assert_response :bad_request
-    assert_equal ({ "error" => "translation missing: en.devise.registrations.user.not_reauthenticated" }),
-                 response.parsed_body
+    assert_translation_missing_error(translation_key: "en.devise.registrations.user.not_reauthenticated")
 
     assert_equal "test@test.com", user.reload.email
 
@@ -436,8 +430,7 @@ class Devise::Passkeys::Controllers::TestRegistrationsControllerConcern < Action
     end
 
     assert_response :bad_request
-    assert_equal ({ "error" => "translation missing: en.devise.registrations.user.not_reauthenticated" }),
-                 response.parsed_body
+    assert_translation_missing_error(translation_key: "en.devise.registrations.user.not_reauthenticated")
 
     assert_equal "test@test.com", user.reload.email
 
@@ -459,8 +452,7 @@ class Devise::Passkeys::Controllers::TestRegistrationsControllerConcern < Action
     end
 
     assert_response :bad_request
-    assert_equal ({ "error" => "translation missing: en.devise.registrations.user.not_reauthenticated" }),
-                 response.parsed_body
+    assert_translation_missing_error(translation_key: "en.devise.registrations.user.not_reauthenticated")
 
     assert_equal "test@test.com", user.reload.email
 

--- a/test/test_helper/extra_assertions.rb
+++ b/test/test_helper/extra_assertions.rb
@@ -1,0 +1,15 @@
+module ExtraAssertions
+  def assert_translation_missing_message(translation_key:)
+    assert_translation_missing(translation_key: translation_key, field: "message")
+  end
+
+  def assert_translation_missing_error(translation_key:)
+    assert_translation_missing(translation_key: translation_key, field: "error")
+  end
+
+  def assert_translation_missing(translation_key:, field:)
+    assert_equal [field], response.parsed_body.keys
+    assert_match /^translation missing/i, response.parsed_body[field]
+    assert_equal true, response.parsed_body[field].include?(translation_key)
+  end
+end


### PR DESCRIPTION
* `i18n` `1.14.0+` changed the format of translation missing error messages, which broke parts of the test suite.
	* To resolve this, we've added `assert_translation_missing_error/message` helpers, which check that
		* The `response.parsed_body` only has 1 field: error or message, depending on the method called
		* That the text of the field inclues "translation missing" (case-insensitive), and that it has the given `translation_key`
* Updated the test suite to use these new helpers

This fixes #5 