### PR TITLE
Configure YARD to use Markdown as the markup format

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,1 @@
+--markup markdown


### PR DESCRIPTION
* Markdown is widly supported & used across the industry (especially when compared to RDOC)