### PR TITLE
Change error on unimplemented party setter

### DIFF
--- a/lib/devise/passkeys/controllers/reauthentication_controller_concern.rb
+++ b/lib/devise/passkeys/controllers/reauthentication_controller_concern.rb
@@ -70,7 +70,7 @@ module Devise
         end
 
         def set_relying_party_in_request_env
-          raise "need to define relying_party for this SessionsController"
+          raise NotImplementedError, "need to define set_relying_party_in_request_env for #{self.class.name}"
         end
       end
     end

--- a/lib/devise/passkeys/controllers/reauthentication_controller_concern.rb
+++ b/lib/devise/passkeys/controllers/reauthentication_controller_concern.rb
@@ -70,7 +70,7 @@ module Devise
         end
 
         def set_relying_party_in_request_env
-          raise NotImplementedError, "need to define set_relying_party_in_request_env for #{self.class.name}"
+          raise NoMethodError, "need to define set_relying_party_in_request_env for #{self.class.name}"
         end
       end
     end

--- a/test/devise/passkeys/controllers/test_reauthentication_controller_concern.rb
+++ b/test/devise/passkeys/controllers/test_reauthentication_controller_concern.rb
@@ -316,10 +316,10 @@ class Devise::Passkeys::Controllers::TestReauthenticationControllerConcernSetup 
     Rails.application.reload_routes!
   end
 
-  test "#new_challenge: raises RuntimeError if set_relying_party_in_request_env has not been implemented" do
+  test "#new_challenge: raises NotImplemented if set_relying_party_in_request_env has not been implemented" do
     user = User.create!(email: "test@test.com")
     sign_in(user)
-    assert_raises RuntimeError do
+    assert_raises NotImplementedError do
       post "/reauthentication/new_challenge"
     end
   end

--- a/test/devise/passkeys/controllers/test_reauthentication_controller_concern.rb
+++ b/test/devise/passkeys/controllers/test_reauthentication_controller_concern.rb
@@ -319,7 +319,7 @@ class Devise::Passkeys::Controllers::TestReauthenticationControllerConcernSetup 
   test "#new_challenge: raises NotImplemented if set_relying_party_in_request_env has not been implemented" do
     user = User.create!(email: "test@test.com")
     sign_in(user)
-    assert_raises NotImplementedError do
+    assert_raises NoMethodError do
       post "/reauthentication/new_challenge"
     end
   end


### PR DESCRIPTION
I think `NotImplementedError` with class name reads better. Also, the message was saying `relying_party` which is confusing in this context, since even if it's implemented we'll still get an error.

On a separate note, @tcannonfodder, why don't we just write a default implementation in, say, `Warden::WebAuthn::StrategyHelpers`? I don't think many users will have a better use for it than
```ruby
def set_relying_party_in_request_env
  request.env[relying_party_key] = relying_party
end
```

Happy to make a pr