### PR TITLE
Refactor Controller concerns to not use `Warden::WebAuthn::StrategyHelpers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- [Bump to warden-webauthn 0.2.1](https://github.com/ruby-passkeys/devise-passkeys/pull/29/commits/d825ffded91aa98801bdd5530442761aa60538f9)
+- [Refactor PasskeysControllerConcern to have clearer credential verify with `verify_credential_integrity`](https://github.com/ruby-passkeys/devise-passkeys/pull/29/commits/f1400cb4b217c20b9e74fda3f55f74284e373d25)
 - Refactor Controller concerns to not use `Warden::WebAuthn::StrategyHelpers`
   - https://github.com/ruby-passkeys/devise-passkeys/pull/29
 - Rename `Devise::Passkeys::Controllers::Concerns::PasskeyReauthentication` => `Devise::Passkeys::Controllers::Concerns::Reauthentication`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Refactor Controller concerns to not use `Warden::WebAuthn::StrategyHelpers`
+  - https://github.com/ruby-passkeys/devise-passkeys/pull/29
 - Rename `Devise::Passkeys::Controllers::Concerns::PasskeyReauthentication` => `Devise::Passkeys::Controllers::Concerns::Reauthentication`
   - https://github.com/ruby-passkeys/devise-passkeys/pull/7/
 - Bump `Devise` requirement to `>= 4.7.1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 - [Bump to warden-webauthn 0.2.1](https://github.com/ruby-passkeys/devise-passkeys/pull/29/commits/d825ffded91aa98801bdd5530442761aa60538f9)
+- [Use `Warden::WebAuthn::RackHelper.set_relying_party_in_request_env` to streamline setup](https://github.com/ruby-passkeys/devise-passkeys/pull/29/commits/7b7d50129ebe83b0a224d0ace0e4cff8ea407f4a)
 - [Refactor PasskeysControllerConcern to have clearer credential verify with `verify_credential_integrity`](https://github.com/ruby-passkeys/devise-passkeys/pull/29/commits/f1400cb4b217c20b9e74fda3f55f74284e373d25)
 - Refactor Controller concerns to not use `Warden::WebAuthn::StrategyHelpers`
   - https://github.com/ruby-passkeys/devise-passkeys/pull/29

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     devise-passkeys (0.1.0)
       devise (>= 4.7.1)
-      warden-webauthn (>= 0.2.0)
+      warden-webauthn (>= 0.2.1)
 
 GEM
   remote: https://rubygems.org/
@@ -157,7 +157,7 @@ GEM
     unicode-display_width (2.4.2)
     warden (1.2.9)
       rack (>= 2.0.9)
-    warden-webauthn (0.2.0)
+    warden-webauthn (0.2.1)
       warden
       webauthn (>= 3)
     webauthn (3.0.0)

--- a/README.md
+++ b/README.md
@@ -96,10 +96,6 @@ class Users::SessionsController < Devise::SessionsController
   def relying_party
      WebAuthn::RelyingParty.new(...)
   end
-
-  def set_relying_party_in_request_env
-    request.env[relying_party_key] = relying_party
-  end
 end
 
 # frozen_string_literal: true
@@ -111,10 +107,6 @@ class Users::ReauthenticationController < DeviseController
   def relying_party
      WebAuthn::RelyingParty.new(...)
   end
-
-  def set_relying_party_in_request_env
-    request.env[relying_party_key] = relying_party
-  end
 end
 
 # frozen_string_literal: true
@@ -125,10 +117,6 @@ class Users::PasskeysController < DeviseController
 
   def relying_party
      WebAuthn::RelyingParty.new(...)
-  end
-
-  def set_relying_party_in_request_env
-    request.env[relying_party_key] = relying_party
   end
 end
 

--- a/devise-passkeys.gemspec
+++ b/devise-passkeys.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   spec.add_dependency "devise", ">= 4.7.1"
-  spec.add_dependency "warden-webauthn", ">= 0.2.0"
+  spec.add_dependency "warden-webauthn", ">= 0.2.1"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/lib/devise/passkeys/controllers/reauthentication_controller_concern.rb
+++ b/lib/devise/passkeys/controllers/reauthentication_controller_concern.rb
@@ -10,7 +10,7 @@ module Devise
           include Devise::Passkeys::Controllers::Concerns::Reauthentication
           include Devise::Passkeys::Controllers::Concerns::ReauthenticationChallenge
           include Warden::WebAuthn::AuthenticationInitiationHelpers
-          include Warden::WebAuthn::StrategyHelpers
+          include Warden::WebAuthn::RackHelpers
 
           prepend_before_action :authenticate_scope!
 

--- a/lib/devise/passkeys/controllers/reauthentication_controller_concern.rb
+++ b/lib/devise/passkeys/controllers/reauthentication_controller_concern.rb
@@ -69,7 +69,7 @@ module Devise
           session.delete(passkey_reauthentication_challenge_session_key)
         end
 
-        def set_relying_party_in_request_env
+        def relying_party
           raise "need to define relying_party for this SessionsController"
         end
       end

--- a/lib/devise/passkeys/controllers/sessions_controller_concern.rb
+++ b/lib/devise/passkeys/controllers/sessions_controller_concern.rb
@@ -8,7 +8,7 @@ module Devise
 
         included do
           include Warden::WebAuthn::AuthenticationInitiationHelpers
-          include Warden::WebAuthn::StrategyHelpers
+          include Warden::WebAuthn::RackHelpers
 
           # Prepending is crucial to ensure that the relying party is set in the
           # request.env before the strategy is executed

--- a/lib/devise/passkeys/controllers/sessions_controller_concern.rb
+++ b/lib/devise/passkeys/controllers/sessions_controller_concern.rb
@@ -29,7 +29,7 @@ module Devise
 
         protected
 
-        def set_relying_party_in_request_env
+        def relying_party
           raise "need to define relying_party for this SessionsController"
         end
       end

--- a/test/devise/passkeys/controllers/test_passkeys_controller_concern.rb
+++ b/test/devise/passkeys/controllers/test_passkeys_controller_concern.rb
@@ -18,10 +18,6 @@ class Devise::Passkeys::Controllers::TestPasskeysControllerConcern < ActionDispa
       WebAuthn::RelyingParty.new(origin: "https://www.example.com")
     end
 
-    def set_relying_party_in_request_env
-      request.env[relying_party_key] = relying_party
-    end
-
     def resource_name
       :user
     end

--- a/test/devise/passkeys/controllers/test_reauthentication_controller_concern.rb
+++ b/test/devise/passkeys/controllers/test_reauthentication_controller_concern.rb
@@ -18,10 +18,6 @@ class Devise::Passkeys::Controllers::TestReauthenticationControllerConcern < Act
       WebAuthn::RelyingParty.new(origin: "https://www.example.com")
     end
 
-    def set_relying_party_in_request_env
-      request.env[relying_party_key] = relying_party
-    end
-
     def resource_name
       :user
     end

--- a/test/devise/passkeys/controllers/test_registrations_controller_concern.rb
+++ b/test/devise/passkeys/controllers/test_registrations_controller_concern.rb
@@ -16,10 +16,6 @@ class Devise::Passkeys::Controllers::TestRegistrationsControllerConcern < Action
       WebAuthn::RelyingParty.new(origin: "https://www.example.com")
     end
 
-    def set_relying_party_in_request_env
-      request.env[relying_party_key] = relying_party
-    end
-
     # Dummy action to setup reauthentication token
     def reauthenticate
       store_reauthentication_token_in_session

--- a/test/devise/passkeys/controllers/test_sessions_controller_concern.rb
+++ b/test/devise/passkeys/controllers/test_sessions_controller_concern.rb
@@ -13,10 +13,6 @@ class Devise::Passkeys::Controllers::TestSessionsControllerConcern < ActionDispa
       WebAuthn::RelyingParty.new(origin: "test.host")
     end
 
-    def set_relying_party_in_request_env
-      request.env[relying_party_key] = relying_party
-    end
-
     def resource_name
       :user
     end
@@ -53,10 +49,6 @@ class Devise::Passkeys::Controllers::TestSessionsControllerConcernCustomization 
 
     def relying_party
       WebAuthn::RelyingParty.new(origin: "test.host")
-    end
-
-    def set_relying_party_in_request_env
-      request.env[relying_party_key] = relying_party
     end
 
     def resource_name


### PR DESCRIPTION
_Note, this cannot be merged in until https://github.com/ruby-passkeys/warden-webauthn/issues/4 is merged and a new gem version is cut_

This PR prevents the bleed-through caused by including all of `Warden::WebAuthn::StrategyHelpers` for a small number of methods.

This resolves #28

(@Vagab I can't add you as a reviewer directly, but would like your feedback on this one as well, since it would solve our discussion: https://github.com/ruby-passkeys/devise-passkeys/pull/25#issuecomment-1605239266)