### PR TITLE
Generate a new CSRF token for the next form submission

### DIFF
--- a/lib/devise/passkeys/controllers/reauthentication_controller_concern.rb
+++ b/lib/devise/passkeys/controllers/reauthentication_controller_concern.rb
@@ -83,7 +83,7 @@ module Devise
         # 5. Ensures that the reauthentication challenge from the session, regardless of any errors
         #
         # @example
-        #  {"reauthentication_token": "abcd1234"}
+        #  {"reauthentication_token": "abcd1234", "new_csrf_token": "4321dcba"}
         #
         # `prepare_params` is called as a `before_action` to prepare the passkey credential for use by the
         # Warden strategy.
@@ -100,7 +100,10 @@ module Devise
 
           store_reauthentication_token_in_session
 
-          render json: { reauthentication_token: stored_reauthentication_token }
+          render json: { 
+            reauthentication_token: stored_reauthentication_token,
+            new_csrf_token: form_authenticity_token
+          }
         ensure
           delete_reauthentication_challenge
         end


### PR DESCRIPTION
### TODO
- [ ] Review devise logic inside `sign_in(resource)` and `sign_out(resource)
The goal is to find way to keep the session as is, but guarantee the details in https://github.com/ruby-passkeys/devise-passkeys/pull/35#issuecomment-1611295505
- [ ] Write tests accordingly

### In this PR
* Module `ReauthenticationControllerConcern` generate and return a new csrf token for the next form submission.

### Template app:
In the template app, after the re-authentication, it is necessary to update the form `authenticity_token` with the value of `new_csrf_token`.

In my own app, I've changed the file passkey_reauthentication_handler.js to use it.
The final lines of the method `getReauthenticationToken`, should add one more line:
```
  const reauthenticationTokenResponse = await(await reauthenticationTokenFetch).json()

  form.elements[reauthenticationTokenFieldName].value = reauthenticationTokenResponseJson.reauthentication_token
  form.elements['authenticity_token'].value = reauthenticationTokenResponseJson.csrf
}
```
