### PR TITLE
Fix `Devise::Strategies::PasskeyReauthentication`: keeps CSRF token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Fixed bug with `Devise::Strategies::PasskeyReauthentication` clearing the CSRF token after reauthentication
+  - https://github.com/ruby-passkeys/devise-passkeys/pull/45
 - Rename `create_resource_and_passkey` => `create_passkey_for_resource`
   - https://github.com/ruby-passkeys/devise-passkeys/pull/37
 - `ReauthenticationControllerConcern` and `SessionsControllerConcern` raise `NoMethodError` if the `relying_party` has not been overridden

--- a/lib/devise/passkeys/reauthentication_strategy.rb
+++ b/lib/devise/passkeys/reauthentication_strategy.rb
@@ -9,6 +9,13 @@ module Devise
       def authentication_challenge_key
         "#{mapping.singular}_current_reauthentication_challenge"
       end
+
+      # Reauthentication runs through Authentication (user_set)
+      # as part of its cycle, which would normally reset CSRF
+      # data in the session
+      def clean_up_csrf?
+        false
+      end
     end
   end
 end


### PR DESCRIPTION
* There was a bug in the reauthentication flow that would reset a session's CSRF token, causing the form to be invalid after reauthenticating.
	* see:
		* https://github.com/ruby-passkeys/devise-passkeys/pull/35
		* https://github.com/ruby-passkeys/devise-passkeys-template/issues/9
	* `Devise::Strategies::Authenticatable` has a `clean_up_csrf?` hook, that defaults to true, but can be overridden to retain the CSRF token after each reauthentication (which is what we want to happen in this case)
* Overrode the method in the Reauthentication strategy, and wrote tests to ensure that the CSRF token is valid
	* Have to temporarily enable the forgery proptection for the reauthentication controller concern

This replaces #35

Also major major props to @heliocola for all his work hammering away at this problem, which helped a ton with debugging & finding the eventual solution