### PR TITLE
Load resource (when email is present) and return allowCredentials

### DIFF
--- a/lib/devise/passkeys/controllers/sessions_controller_concern.rb
+++ b/lib/devise/passkeys/controllers/sessions_controller_concern.rb
@@ -20,7 +20,8 @@ module Devise
         end
 
         def new_challenge
-          options_for_authentication = generate_authentication_options(relying_party: relying_party)
+          options_for_authentication = generate_authentication_options(relying_party: relying_party,
+            options: (resource_allow_credentials || {}))
 
           store_challenge_in_session(options_for_authentication: options_for_authentication)
 
@@ -32,6 +33,23 @@ module Devise
         def relying_party
           raise NoMethodError, "need to define relying_party for this #{self.class.name}"
         end
+
+        def resource_allow_credentials
+          resource_signing_in ? ({allow: resource_signing_in.passkeys.pluck(:external_id)}) : nil
+        end
+
+        def resource_signing_in
+          @resource_signing_in ||= resource_class.find_by(email: resource_params[:email])
+        end
+
+        def resource_params
+          params.require(resource_name).permit(:email)
+        end
+
+        def resource_class
+          resource_name.to_s.capitalize.constantize
+        end
+
       end
     end
   end


### PR DESCRIPTION
### Context
Sign in for Android phones are not working
Fixes: https://github.com/ruby-passkeys/devise-passkeys-template/issues/12

### In this PR
Sign in `new_challenge` method load the resource, when email is present, and return `allowCredentials` so Android phones can find a passkey for the website and request the biometrics.
