### PR TITLE
Remove default `add_module` for passkey strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.3.0] - 2023-08-18
+
+### Bugfixes
+
+- Remove default `Devise.add_module`, remove incorrect `no_input: true` declaration in documentation
+  - https://github.com/ruby-passkeys/devise-passkeys/pull/48
+
 ## [0.2.0] - 2023-07-07
 
 ### Bugfixes

--- a/README.md
+++ b/README.md
@@ -164,8 +164,7 @@ Devise.add_module :passkey_authenticatable,
                   model: 'devise/passkeys/model',
                   route: {session: [nil, :new, :create, :destroy] },
                   controller: 'controller/sessions',
-                  strategy: true,
-                  no_input: true
+                  strategy: true
 ```
 
 # FAQs

--- a/lib/devise/passkeys.rb
+++ b/lib/devise/passkeys.rb
@@ -44,8 +44,3 @@ module Devise
     end
   end
 end
-
-Devise.add_module :passkey_authenticatable,
-                  model: "devise/passkeys/model",
-                  strategy: true,
-                  no_input: true

--- a/lib/devise/passkeys/version.rb
+++ b/lib/devise/passkeys/version.rb
@@ -2,6 +2,6 @@
 
 module Devise
   module Passkeys
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
   end
 end


### PR DESCRIPTION
# Proposed change

Remove the default call to `Devise.add_module` for the `:passkey_authenticatable` strategy.

# Reasoning

The default call adds `no_input: true` for the strategy which effectively bypasses `sign_in`, as well as `after_action` controller filters.

## Details

With `no_input: true` enabled for the passkey devise strategy it will be considered when checking for already-authenticated sessions in `DeviseController::require_no_authentication`.

When submitting valid passkey credentials to `Sessions#create`, `require_no_authentication` runs before the action and tries to authenticate against all of the strategies flagged with `no_input`. If it finds one, it halts, devise adds an already logged in flash message, and redirects to the `after_sign_in_path_for(resource)`, instead of going through the session create action.

This bypasses any user-created `after_action`  filters, and more importantly, the `sign_in` method, both of which may be important for rails apps.

The `no_input` option can't be changed in userland without manually altering devise constants, because the default `Devise.add_module` here: https://github.com/ruby-passkeys/devise-passkeys/blob/9a57c20900aebeef93441badfbc6211ff6a77531/lib/devise/passkeys.rb#L48-L51 mutates the `Devise::NO_INPUT` constant and a couple of others.

Since the readme currently calls out needing to call `Devise.add_module` manually during setup, I've just removed the offending `add_module` and changed the readme recommendation to not include `no_input`.

## Tests

Tests pass using `warden-webauthn = 0.2.1`, but `0.3.0` adds a new default value (`resident_key: required`) that affects some tests.

