### PR TITLE
Bump `warden-webauthn` requirement to `>= 3.0.0`, fix tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    devise-passkeys (0.2.0)
+    devise-passkeys (0.3.0)
       devise (>= 4.7.1)
-      warden-webauthn (>= 0.2.1)
+      warden-webauthn (>= 0.3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -104,7 +104,7 @@ GEM
       ast (~> 2.4.1)
       racc
     racc (1.7.1)
-    rack (2.2.7)
+    rack (2.2.8)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails-dom-testing (2.1.1)
@@ -163,7 +163,7 @@ GEM
     unicode-display_width (2.4.2)
     warden (1.2.9)
       rack (>= 2.0.9)
-    warden-webauthn (0.2.1)
+    warden-webauthn (0.3.0)
       warden
       webauthn (>= 3)
     webauthn (3.0.0)

--- a/devise-passkeys.gemspec
+++ b/devise-passkeys.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   spec.add_dependency "devise", ">= 4.7.1"
-  spec.add_dependency "warden-webauthn", ">= 0.2.1"
+  spec.add_dependency "warden-webauthn", ">= 0.3.0"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/test/devise/passkeys/controllers/test_passkeys_controller_concern.rb
+++ b/test/devise/passkeys/controllers/test_passkeys_controller_concern.rb
@@ -82,7 +82,7 @@ class Devise::Passkeys::Controllers::TestPasskeysControllerConcern < ActionDispa
     assert_equal 120_000, response_json["timeout"]
     assert_equal ({}), response_json["extensions"]
     assert_equal excluded_credentials, response_json["excludeCredentials"]
-    assert_equal ({ "userVerification" => "required" }), response_json["authenticatorSelection"]
+    assert_equal ({ "residentKey" => "required", "userVerification" => "required" }), response_json["authenticatorSelection"]
   end
 
   test "#create: creates a passkey for the user" do
@@ -115,7 +115,7 @@ class Devise::Passkeys::Controllers::TestPasskeysControllerConcern < ActionDispa
     assert_equal 120_000, response_json["timeout"]
     assert_equal ({}), response_json["extensions"]
     assert_equal excluded_credentials, response_json["excludeCredentials"]
-    assert_equal ({ "userVerification" => "required" }), response_json["authenticatorSelection"]
+    assert_equal ({ "residentKey" => "required", "userVerification" => "required" }), response_json["authenticatorSelection"]
 
     raw_credential = client.create(challenge: response_json["challenge"], user_verified: true)
 
@@ -189,7 +189,7 @@ class Devise::Passkeys::Controllers::TestPasskeysControllerConcern < ActionDispa
     assert_equal 120_000, response_json["timeout"]
     assert_equal ({}), response_json["extensions"]
     assert_equal excluded_credentials, response_json["excludeCredentials"]
-    assert_equal ({ "userVerification" => "required" }), response_json["authenticatorSelection"]
+    assert_equal ({ "residentKey" => "required", "userVerification" => "required" }), response_json["authenticatorSelection"]
 
     raw_credential = client.create(challenge: response_json["challenge"], user_verified: false)
 
@@ -237,7 +237,7 @@ class Devise::Passkeys::Controllers::TestPasskeysControllerConcern < ActionDispa
     assert_equal 120_000, response_json["timeout"]
     assert_equal ({}), response_json["extensions"]
     assert_equal excluded_credentials, response_json["excludeCredentials"]
-    assert_equal ({ "userVerification" => "required" }), response_json["authenticatorSelection"]
+    assert_equal ({ "residentKey" => "required", "userVerification" => "required" }), response_json["authenticatorSelection"]
 
     raw_credential = client.create(challenge: "blah", user_verified: true)
 
@@ -360,7 +360,7 @@ class Devise::Passkeys::Controllers::TestPasskeysControllerConcern < ActionDispa
     assert_equal 120_000, response_json["timeout"]
     assert_equal ({}), response_json["extensions"]
     assert_equal excluded_credentials, response_json["excludeCredentials"]
-    assert_equal ({ "userVerification" => "required" }), response_json["authenticatorSelection"]
+    assert_equal ({ "residentKey" => "required", "userVerification" => "required" }), response_json["authenticatorSelection"]
 
     raw_credential = client.create(challenge: response_json["challenge"], user_verified: true)
 
@@ -405,7 +405,7 @@ class Devise::Passkeys::Controllers::TestPasskeysControllerConcern < ActionDispa
     assert_equal 120_000, response_json["timeout"]
     assert_equal ({}), response_json["extensions"]
     assert_equal excluded_credentials, response_json["excludeCredentials"]
-    assert_equal ({ "userVerification" => "required" }), response_json["authenticatorSelection"]
+    assert_equal ({ "residentKey" => "required", "userVerification" => "required" }), response_json["authenticatorSelection"]
 
     raw_credential = client.create(challenge: response_json["challenge"], user_verified: true)
 

--- a/test/devise/passkeys/controllers/test_registrations_controller_concern.rb
+++ b/test/devise/passkeys/controllers/test_registrations_controller_concern.rb
@@ -71,7 +71,7 @@ class Devise::Passkeys::Controllers::TestRegistrationsControllerConcern < Action
     assert_equal 120_000, response_json["timeout"]
     assert_equal ({}), response_json["extensions"]
     assert_empty response_json["excludeCredentials"]
-    assert_equal ({ "userVerification" => "required" }), response_json["authenticatorSelection"]
+    assert_equal ({ "residentKey" => "required", "userVerification" => "required" }), response_json["authenticatorSelection"]
   end
 
   test "#create: success" do


### PR DESCRIPTION
* Tests needed to be updated to reflect the new `"residentKey"=>"required"` option that is used by default