### PR TITLE
Use Devise configuration for auth_keys, instead of email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ group :development, :test do
   gem "debug"
   gem "rake", "~> 13.0"
   gem "rubocop", "~> 1.21"
-  gem 'yard'
-  gem 'webrick'
+  gem "webrick"
+  gem "yard"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,6 +181,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/gemfiles/rails_6.gemfile
+++ b/gemfiles/rails_6.gemfile
@@ -10,8 +10,8 @@ group :development, :test do
   gem "debug"
   gem "rake", "~> 13.0"
   gem "rubocop", "~> 1.21"
-  gem "yard"
   gem "webrick"
+  gem "yard"
 end
 
 group :test do

--- a/gemfiles/rails_7.gemfile
+++ b/gemfiles/rails_7.gemfile
@@ -10,8 +10,8 @@ group :development, :test do
   gem "debug"
   gem "rake", "~> 13.0"
   gem "rubocop", "~> 1.21"
-  gem "yard"
   gem "webrick"
+  gem "yard"
 end
 
 group :test do

--- a/lib/devise/passkeys/controllers/concerns/reauthentication_challenge.rb
+++ b/lib/devise/passkeys/controllers/concerns/reauthentication_challenge.rb
@@ -31,6 +31,14 @@ module Devise
             "#{resource_name}_current_reauthentication_challenge"
           end
 
+          # This method is responsible for generating the the object class for Devise resource name
+          # that will be used to find the authentication_keys configured in Devise
+          #
+          # @return [Object] The Devise resource name, as an object
+          def resource_class
+            Object.const_get(resource_name.to_s.camelize)
+          end
+
           # This method is responsible for storing the reauthentication challenge in the session.
           #
           # @param [WebAuthn::PublicKeyCredential::RequestOptions] options_for_authentication the options for authentication,

--- a/lib/devise/passkeys/controllers/concerns/reauthentication_challenge.rb
+++ b/lib/devise/passkeys/controllers/concerns/reauthentication_challenge.rb
@@ -31,14 +31,6 @@ module Devise
             "#{resource_name}_current_reauthentication_challenge"
           end
 
-          # This method is responsible for generating the the object class for Devise resource name
-          # that will be used to find the authentication_keys configured in Devise
-          #
-          # @return [Object] The Devise resource name, as an object
-          def resource_class
-            Object.const_get(resource_name.to_s.camelize)
-          end
-
           # This method is responsible for storing the reauthentication challenge in the session.
           #
           # @param [WebAuthn::PublicKeyCredential::RequestOptions] options_for_authentication the options for authentication,

--- a/lib/devise/passkeys/controllers/passkeys_controller_concern.rb
+++ b/lib/devise/passkeys/controllers/passkeys_controller_concern.rb
@@ -90,7 +90,7 @@ module Devise
         end
 
         def user_details_for_registration
-          { id: resource.webauthn_id, name: resource.email }
+          { id: resource.webauthn_id, name: resource.send(resource_class.authentication_keys.first) }
         end
 
         def verify_credential_integrity


### PR DESCRIPTION
### Goal
* Use the configuration value for Devise `authentication_keys`, instead of assuming `:email`

### Included while reviewing `bundle exec rubocop`
* Fixed a few rubocop issues
* Added documentation to surrounding methods

### Why
This allows apps that uses `username` (or any, other than `email`) as the Devise `authentication_key` to work

### Outside of the scope of this PR
* Add support to multiple authentication keys (`[:username, :subdomain]`, `[:email, :account_id]`, ...)

### Still TODO
- [ ] Add tests for Devise auth_key `username`
- [x] Remove unnecessary `resource_class` method as Devise already provide one!
- [ ] Add a default implementation of `default_passkey_name` (ref: https://github.com/ruby-passkeys/devise-passkeys/pull/50#discussion_r1314277788)
